### PR TITLE
Avoid unnecessary sysfs lookup when already fell back

### DIFF
--- a/SOURCES/lvm2-2_02_183-vts-skip-unnecessary-sysfs-scan.patch
+++ b/SOURCES/lvm2-2_02_183-vts-skip-unnecessary-sysfs-scan.patch
@@ -1,0 +1,7 @@
+--- a/lib/device/dev-cache.c	2026-03-23 15:16:17.275118234 +0100
++++ b/lib/device/dev-cache.c	2026-03-24 08:12:11.708172490 +0100
+@@ -1595,3 +1595,3 @@
+ 		sysfs_dir = dm_sysfs_dir();
+-		if (sysfs_dir && *sysfs_dir) {
++		if (sysfs_dir && *sysfs_dir && MAJOR(dev)) {
+ 			/* First check if dev is sysfs to avoid useless scan */


### PR DESCRIPTION
This patch prevents unnecessary sysfs scan when `MAJOR(dev)=0` (i.e. when `_pv_populate_lvmcache` fell back)